### PR TITLE
Fixed broken link of edit exhibit page.

### DIFF
--- a/EditLinkPlugin.php
+++ b/EditLinkPlugin.php
@@ -34,7 +34,7 @@ class EditLinkPlugin extends Omeka_Plugin_AbstractPlugin
         if(is_allowed($aclRecord, 'edit')) {
             set_theme_base_url('admin');
             if(get_class($record) == 'ExhibitPage') {
-                $url = url('exhibits/edit-page-content/' . $record->id);
+                $url = url('exhibits/edit-page/' . $record->id);
             } else {
                 $url = record_url($record, 'edit');
             }


### PR DESCRIPTION
There is a problem with the edit exhibit page links, which went to an error page. I fixed the URL in the plugin php file so now the edit link could direct user to edit page properly.